### PR TITLE
Potential fix for code scanning alert no. 4: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3330,7 +3330,7 @@ d-citation-list .references .title {
     Prism.languages.insertBefore("javascript", "keyword", {
       regex: {
         pattern:
-          /((?:^|[^$\w\xA0-\uFFFF."'\])\s])\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*[\s\S]*?\*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
+          /((?:^|[^$\w\xA0-\uFFFF."'\])\s])\s*)\/(?:\[(?:[^\]\\\r\n]|\\.)*]|\\.|[^/\\\[\r\n])+\/[gimyus]{0,6}(?=(?:\s|\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/)*(?:$|[\r\n,.;:})\]]|\/\/))/,
         lookbehind: true,
         greedy: true,
       },


### PR DESCRIPTION
Potential fix for [https://github.com/ardyseto/ardyseto.github.io/security/code-scanning/4](https://github.com/ardyseto/ardyseto.github.io/security/code-scanning/4)

To fix this without changing functionality, replace the ambiguous lazy-anything block-comment matcher `\/\*[\s\S]*?\*\/` with a linear-time block-comment pattern that avoids catastrophic backtracking:

- Use: `\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/`

This is a standard safe regex for C/JS-style block comments. It matches the same comment form (`/* ... */`) but does so without the problematic nested backtracking behavior from `[\s\S]*?`.

In `assets/js/distillpub/template.v2.js`, edit the regex at line 3333 inside the `lookahead` tail:
- From: `(?:\s|\/\*[\s\S]*?\*\/)*`
- To:   `(?:\s|\/\*[^*]*\*+(?:[^/*][^*]*\*+)*\/)*`

No imports, new methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
