### PR TITLE
Potential fix for code scanning alert no. 3: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3170,7 +3170,7 @@ d-citation-list .references .title {
         var def = {};
         def[tagName] = {
           pattern: RegExp(
-            /(<__[\s\S]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[\s\S])*?(?=<\/__>)/.source.replace(/__/g, function () {
+            /(<__[\s\S]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|(?:(?!<\/__>)[\s\S]))*(?=<\/__>)/.source.replace(/__/g, function () {
               return tagName;
             }),
             "i"


### PR DESCRIPTION
Potential fix for [https://github.com/ardyseto/ardyseto.github.io/security/code-scanning/3](https://github.com/ardyseto/ardyseto.github.io/security/code-scanning/3)

The best fix is to remove ambiguity by avoiding the nested “any char” repetition with alternation. Specifically, in `assets/js/distillpub/template.v2.js` around line 3173, replace:

- `(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[\s\S])*?`

with a linear-time style tempered scan that consumes either:
- a full CDATA block, or
- one character that does **not** start a closing tag (`</__>`),

repeated greedily until `</__>`.

A robust replacement is:

- `(?:<!\[CDATA\[[\s\S]*?\]\]>\\s*|(?:(?!<\\/__>)[\\s\\S]))*`

This preserves behavior (consume content up to the closing tag, allowing CDATA sections) while removing the catastrophic nested ambiguity that caused exponential backtracking.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
