### PR TITLE
Potential fix for code scanning alert no. 2: Inefficient regular expression

### DIFF
--- a/assets/js/distillpub/template.v2.js
+++ b/assets/js/distillpub/template.v2.js
@@ -3170,7 +3170,7 @@ d-citation-list .references .title {
         var def = {};
         def[tagName] = {
           pattern: RegExp(
-            /(<__[\s\S]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[\s\S])*?(?=<\/__>)/.source.replace(/__/g, function () {
+            /(<__[\s\S]*?>)(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|<(?!\!\[CDATA\[)|[^<])*?(?=<\/__>)/.source.replace(/__/g, function () {
               return tagName;
             }),
             "i"


### PR DESCRIPTION
Potential fix for [https://github.com/ardyseto/ardyseto.github.io/security/code-scanning/2](https://github.com/ardyseto/ardyseto.github.io/security/code-scanning/2)

To fix this without changing behavior, rewrite the ambiguous repeated alternation so alternatives are disjoint.  
Best approach here: replace

- `(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|[\s\S])*?`

with

- `(?:<!\[CDATA\[[\s\S]*?\]\]>\s*|<(?!\!\[CDATA\[)|[^<])*?`

Why this works:
- It still matches the same overall content until `(?=<\/__>)`.
- CDATA blocks are matched by the first branch.
- Non-CDATA content is matched by either:
  - `<(?!\!\[CDATA\[)` for `<` not starting a CDATA opener, or
  - `[^<]` for all other chars.
- This removes overlap with the CDATA branch, preventing combinatorial backtracking.

Only edit the regex at `assets/js/distillpub/template.v2.js` around line 3173. No imports or new helpers are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
